### PR TITLE
Add user agent

### DIFF
--- a/lib/prerender.js
+++ b/lib/prerender.js
@@ -152,6 +152,7 @@ prerender.onPhantomPageCreate = function(req, res) {
     req.prerender.page.set('onResourceRequested', function (requestData) { req.prerender.pendingRequests++; });
     req.prerender.page.set('onResourceReceived', function (response) { if ('end' === response.stage) { req.prerender.pendingRequests--; } });
     req.prerender.page.set('onResourceError', function(resourceError) { req.prerender.pendingRequests--; });
+    req.prerender.page.setHeaders({'User-Agent': 'Prerender (+https://github.com/collectiveip/prerender)'});
 
     this.pluginsOnPhantomPageCreate(req, res, function(){
 


### PR DESCRIPTION
I faced with an unwanted effect when rendering a static version of the site. When GoogleBot request a page the web application proxies the request to a prerender. Prerender renders static html and executes javascript(include google analytics). This behavior can disrupt the accuracy of statistics if site has many pages.

As workaround, I suggest to parse user agent and do not insert google analytics script for a prerender.
