### PR TITLE
Update remove-script-tags.js

### DIFF
--- a/lib/plugins/remove-script-tags.js
+++ b/lib/plugins/remove-script-tags.js
@@ -4,7 +4,7 @@ module.exports = {
     		return next();
     	}
 
-        var matches = req.prerender.documentHTML.match(/<script(?:.*?)>(?:[\S\s]*?)<\/script>/gi);
+        var matches = req.prerender.documentHTML.toString().match(/<script(?:.*?)>(?:[\S\s]*?)<\/script>/gi);
         for (var i = 0; matches && i < matches.length; i++) {
             req.prerender.documentHTML = req.prerender.documentHTML.replace(matches[i], '');
         }


### PR DESCRIPTION
Added .toString() to stringify the HTML being passed back by S3 when a page has been previously cached.

Verified this is working on my production instance of Prerender with previously cached files on S3.
