### PR TITLE
Procfile entry to restart heroku dynos

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: node index.js
+restarter: ./bin/restart-heroku


### PR DESCRIPTION
This adds an entry to the Procfile to restart dynos, so that it can be run by, e.g. the heroku scheduler
