### PR TITLE
Allow further customization of server port

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -36,10 +36,11 @@ function PrerenderServer(phantom) {
 util.inherits(PrerenderServer, PrerenderEngine);
 
 // Starts the server
-PrerenderServer.prototype.start = function() {
+PrerenderServer.prototype.start = function(port) {
+    port = port || process.env.PRERENDER_PORT || process.env.PORT || 3000;
     this.phantom.start();
-    http.createServer(_.bind(this.onRequest, this)).listen(process.env.PORT || 3000);
-    console.log('Server running on port ' + (process.env.PORT || 3000));
+    http.createServer(_.bind(this.onRequest, this)).listen(port);
+    console.log('Server running on port ' + port);
 };
 
 // Called when a web request comes in

--- a/lib/server.js
+++ b/lib/server.js
@@ -37,7 +37,7 @@ util.inherits(PrerenderServer, PrerenderEngine);
 
 // Starts the server
 PrerenderServer.prototype.start = function(port) {
-    port = port || process.env.PRERENDER_PORT || process.env.PORT || 3000;
+    port = port || process.env.PORT || 3000;
     this.phantom.start();
     http.createServer(_.bind(this.onRequest, this)).listen(port);
     console.log('Server running on port ' + port);


### PR DESCRIPTION
- Check for PRERENDER_PORT environment variable (PORT is generic and can be conflicting)
- Port number can also be passed in directly when calling start
- Doesn't break current behavior
