### PR TITLE
Support Phantom Cluster using customized ports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,10 @@ var cluster = require('cluster')
 exports = module.exports = function(options) {
     var port = options.port || process.env.PORT || 3000;
 
+    if(!options.phantomBasePort) {
+        options.phantomBasePort = process.env.PHANTOM_CLUSTER_BASE_PORT || 12300;
+    }
+
     var server = require('./server');
     options.isMaster = cluster.isMaster;
     options.worker = cluster.worker;

--- a/lib/server.js
+++ b/lib/server.js
@@ -68,6 +68,7 @@ server.createPhantom = function() {
     }
 
     arguments.push({
+        port: this.options.phantomBasePort || 12300,
         binary: require('phantomjs').path,
         onExit: function() {
             _this.phantom = null;

--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ var prerender = require('./lib')
 var server = prerender({
     workers: process.env.PHANTOM_CLUSTER_NUM_WORKERS,
     iterations: process.env.PHANTOM_WORKER_ITERATIONS || 10,
-    phantomBasePort: process.env.PHANTOM_CLUSTER_BASE_PORT,
+    phantomBasePort: process.env.PHANTOM_CLUSTER_BASE_PORT || 12300,
     messageTimeout: process.env.PHANTOM_CLUSTER_MESSAGE_TIMEOUT
 });
 


### PR DESCRIPTION
phantomBasePort control came in with abd714517af15c1432b674e12debe32ab98f9bad, but didn't get wired up throughout.

This PR completes that functionality, sticking with phantomjs' default port of 12300 but allowing overrides via option phantomBasePort in server.js, or env variable of PHANTOM_CLUSTER_BASE_PORT.

This functionality, combined with changing PORT, allows multiple prerender servers to run on the same machine (useful for load balancing)
