### PR TITLE
Add base path to prerender url

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ curl -u prerender:wrong http://localhost:1337/http://example.com -> 401
 curl -u prerender:test http://localhost:1337/http://example.com -> 200
 ```
 
+### serverPath
+
+By default Prerender don't have a server path, you can access server by HOST[:PORT]. But there are case, where a base path in the server is needed.
+
+To set the base path you need to add the `SERVER_BASE_PATH` environment variables.
+```
+export SERVER_BASE_PATH=prerender/
+```
+
+With this configuration, you can now access Prerender through:
+
+```
+http://HOST[:PORT]/prerender/
+```
+
 ### removeScriptTags
 
 We remove script tags because we don't want any framework specific routing/rendering to happen on the rendered HTML once it's executed by the crawler. The crawlers may not execute javascript, but we'd rather be safe than have something get screwed up.

--- a/lib/plugins/serverPath.js
+++ b/lib/plugins/serverPath.js
@@ -1,0 +1,22 @@
+
+module.exports = {
+	init: function() {
+		this.SERVER_BASE_PATH = process.env.SERVER_BASE_PATH;
+	},
+    beforePhantomRequest: function(req, res, next) {
+
+        if (this.SERVER_BASE_PATH){
+        // Check the base path in the request url
+            if(req.prerender.url.indexOf(this.SERVER_BASE_PATH) == 0){
+                //Remove the base path from request url
+                req.prerender.url = req.prerender.url.substr(this.SERVER_BASE_PATH.length);
+                console.log("NEW URL ->" + req.prerender.url);
+            } else {
+                res.send(404);
+                return;
+            }
+        }
+
+        next();
+    }
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,8 +3,6 @@ var phantom = require('phantom')
   , util = require('./util.js')
   , zlib = require('zlib');
 
-var SERVER_BASE_PATH = process.env.SERVER_BASE_PATH;
-
 var PAGE_DONE_CHECK_TIMEOUT = process.env.PAGE_DONE_CHECK_TIMEOUT || 50;
 
 var RESOURCE_DOWNLOAD_TIMEOUT = process.env.RESOURCE_DOWNLOAD_TIMEOUT || 10 * 1000;
@@ -92,19 +90,6 @@ server.onPhantomCreate = function(phantom) {
 
 server.onRequest = function(req, res) {
     var _this = this;
-
-    if (SERVER_BASE_PATH){
-        // Check the base path in the request url
-        if(req.url.indexOf(SERVER_BASE_PATH) == 0){
-            //Remove the base path from request url
-            req.url = req.url.substr(SERVER_BASE_PATH.length);
-        } else {
-            res.writeHead(404, {"Content-Type": "text/plain"});
-            res.write("404 Not Found\n");
-            res.end();
-            return;
-        }
-    }
 
     // Create a partial out of the _send method for the convenience of plugins
     res.send = _.bind(this._send, this, req, res);

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ var server = prerender({
 
 
 // server.use(prerender.basicAuth());
+// server.use(prerender.serverPath());
 // server.use(prerender.whitelist());
 server.use(prerender.blacklist());
 // server.use(prerender.logger());


### PR DESCRIPTION
This parameter is useful when in your internal infrastructure, the network traffic go through one endpoint ( ip or host ). Ej:

http://mycompany.servers.com/app1/service1/....
http://mycompany.servers.com/app2/service1/....
http://mycompany.servers.com/app3/service1/....

It would be very nice to be able to set something like:

http://mycompany.servers.com/prerender/http://www.....
