### PR TITLE
fix for httpHeaders plugin when working with minified html

### DIFF
--- a/lib/plugins/httpHeaders.js
+++ b/lib/plugins/httpHeaders.js
@@ -1,20 +1,39 @@
 module.exports = {
     beforeSend: function(req, res, next) {
         if(req.prerender.documentHTML) {
-            var statusMatch = /<meta.*?name=['"]prerender-status-code['"] content=['"]([0-9]{3})['"].*?\/?>/i,
-                headerMatch = /<meta.*?name=['"]prerender-header['"] content=['"](.*?): ?(.*?)['"].*?\/?>/gi,
-                head = req.prerender.documentHTML.toString().split('</head>', 1).pop(),
-                statusCode = 200,
-                match;
 
-            if (match = statusMatch.exec(head)) {
-                statusCode = match[1];
-                req.prerender.documentHTML = req.prerender.documentHTML.toString().replace(match[0], '');
+            var html = req.prerender.documentHTML.toString(),
+                statusCode = 200,
+                metaTagExpr = /<meta(?:\s*(?:[^\/>=]+)(?:=(?:'[^']*'|"[^"]*"))?)*\s*\/?>/gi,
+                nameExpr = /name=['"]([^'"]*)['"]/i,
+                codeExpr = /content=['"](\d{3})['"]/i,
+                headerExpr = /content=['"]([^'"]*?): ?([^'"]*?)['"]/i,
+                toRemove = [], 
+                metaTagMatch, nameMatch, codeMatch, headerMatch;
+
+            while ((metaTagMatch = metaTagExpr.exec(html))) {
+                if((nameMatch = nameExpr.exec(metaTagMatch[0]))){
+
+                    if(nameMatch[1] === 'prerender-status-code' &&
+                        (codeMatch = codeExpr.exec(metaTagMatch[0]))){
+                        statusCode = codeMatch[1];
+                        toRemove.push(metaTagMatch[0]);
+                    }
+
+                    if (nameMatch[1] === 'prerender-header' &&
+                        (headerMatch = headerExpr.exec(metaTagMatch[0]))) {
+                        res.setHeader(headerMatch[1], headerMatch[2]);
+                        toRemove.push(metaTagMatch[0]);
+                    }
+                }
             }
 
-            while (match = headerMatch.exec(head)) {
-                res.setHeader(match[1], match[2]);
-                req.prerender.documentHTML = req.prerender.documentHTML.toString().replace(match[0], '');
+            if(toRemove.length) {
+                var item;
+                while ((item = toRemove.pop())) {
+                    html = html.replace(item, '');
+                }
+                req.prerender.documentHTML = html;
             }
 
             if (res.getHeader('Location')) {


### PR DESCRIPTION
There was a bug when using with minified html code (almost whole page in single line),

httpHeaders was removing not only `prerender-status-code` and `prerender-header` meta tags, but whole lines with this tags(in my case it was title, description and open graph properties).
