### PR TITLE
Do not add Location header when following redirect

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -361,7 +361,7 @@ server._send = function(req, res, statusCode, options) {
     }
 
     this._pluginEvent("beforeSend", [req, res], function() {
-        if (req.prerender.redirectURL) {
+        if (req.prerender.redirectURL && !(_this.options.followRedirect || process.env.FOLLOW_REDIRECT)) {
             res.setHeader('Location', req.prerender.redirectURL);
         }
 


### PR DESCRIPTION
With the FOLLOW_REDIRECT option on, it still adds the `Location` header.
