### PR TITLE
Workaround for phantomjs zombie processes / memory leaks

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -28,6 +28,10 @@ server.init = function(options) {
     // used to rotate the port for our worker
     this.options.portModulo = 0;
 
+    if (this.options.worker) {
+        this.options.worker.count = 0;
+    }
+
     return this;
 };
 
@@ -453,8 +457,10 @@ server._sendResponse = function(req, res, options) {
     var ms = new Date().getTime() - req.prerender.start.getTime();
     util.log('got', req.prerender.statusCode, 'in', ms + 'ms', 'for', req.prerender.url);
 
-    if(options && options.abort) {
-        this._killPhantomJS();
+    this.options.worker.count += 1;
+
+    if((this.options.iterations && this.options.worker.count >= this.options.iterations) || (options && options.abort)) {
+        server._killPhantomJS();
     }
 };
 
@@ -468,4 +474,4 @@ server._killPhantomJS = function() {
        // } catch(e) {
        //     util.log('Error killing phantomjs from javascript infinite loop:', e);
        // }
-}
+};


### PR DESCRIPTION
I know you guys run a script that periodically kills the whole process, but for those who don't like to do that maybe this could be a good solution for now ...

it's using the 'iterations' config again (which you had removed yourself but was still in the documentation xD).  
will kill phantom every 10th request.  
will rotate between 3 ports for every worker, because sometimes phantomjs won't die fast enough and once you start hitting the EADDRINUSE error it's an infinite loop of killing and respawning phantomjs instances until your machine dies ...

when iterations is 0 the killing of phantomjs is disabled, so maybe you could set the iterations config to 0 by default in server.js instead of 10 (which wasn't doing anything right now) so that this feature is also disabled by default.
