### PR TITLE
another atempt at getting prerender to be stable without a cron killing it

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,10 +29,7 @@ exports = module.exports = function(options) {
         }
 
         cluster.on('exit', function (worker) {
-
-            util.log('worker ' + worker.id + ' died.');
-            // spin up another to replace it
-            util.log('Restarting worker thread...');
+            util.log('worker ' + worker.id + ' died, restarting!');
             cluster.fork();
         });
     } else {

--- a/lib/server.js
+++ b/lib/server.js
@@ -495,7 +495,8 @@ server._sendResponse = function(req, res, options) {
 };
 
 server._killPhantomJS = function() {
-    this.options.worker.kill('SIGKILL');
+    // this.options.worker.kill('SIGTERM');
+    require('tree-kill')(this.options.worker.process.pid, 'SIGTERM');
        //  try {
        //     //not happy with this... but when phantomjs is hanging, it can't exit any normal way
        //     util.log('pkilling phantomjs');

--- a/lib/server.js
+++ b/lib/server.js
@@ -25,6 +25,11 @@ server.init = function(options) {
     this.plugins = this.plugins || [];
     this.options = options;
 
+
+    if (this.options.worker) {
+        this.options.worker.iteration = 0;
+    }
+
     return this;
 };
 
@@ -63,17 +68,19 @@ server._pluginEvent = function(methodName, args, callback) {
 
 server.createPhantom = function() {
     var _this = this;
-    util.log('starting phantom');
 
     var args = ["--load-images=false", "--ignore-ssl-errors=true", "--ssl-protocol=tlsv1"];
-    var port = this.options.phantomBasePort || 12300;
 
     if(this.options.phantomArguments) {
         args = this.options.phantomArguments;
     }
 
+    var port = (this.options.phantomBasePort || 12300) + (this.options.worker.id % 200);
+
+    util.log('starting phantom on port [' + port + ']');
+
     var opts = {
-        port: port + this.options.worker.id,
+        port: port,
         binary: require('phantomjs').path,
         onExit: function() {
             _this.phantom = null;
@@ -480,13 +487,15 @@ server._sendResponse = function(req, res, options) {
     var ms = new Date().getTime() - req.prerender.start.getTime();
     util.log('got', req.prerender.statusCode, 'in', ms + 'ms', 'for', req.prerender.url);
 
-    if(options && options.abort) {
-        this._killPhantomJS();
+    this.options.worker.iteration += 1;
+
+    if((this.options.iterations && this.options.worker.iteration >= this.options.iterations) || (options && options.abort)) {
+        server._killPhantomJS();
     }
 };
 
 server._killPhantomJS = function() {
-    this.options.worker.kill();
+    this.options.worker.kill('SIGKILL');
        //  try {
        //     //not happy with this... but when phantomjs is hanging, it can't exit any normal way
        //     util.log('pkilling phantomjs');
@@ -495,4 +504,4 @@ server._killPhantomJS = function() {
        // } catch(e) {
        //     util.log('Error killing phantomjs from javascript infinite loop:', e);
        // }
-}
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "cache-manager": "0.2.0",
     "lodash": "~2.4.0",
     "phantom": "~0.5.7",
-    "phantomjs": "~1.9.7-1"
+    "phantomjs": "~1.9.7-1",
+    "tree-kill": "0.0.6"
   },
   "bin": {
     "prerender": "server.js"


### PR DESCRIPTION
So I'm still trying to get prerender to be stable without the need of a cronjob (or heroku task) to kill it ...
It has been stable now for ~36 hours, which is a new record (and I got my first night of sleep without pagerduty waking me up for a server that was running hot).  
Maybe someone else can give it a shot to see if their issues are also solved ;-)


--------------
So I reenabled the 'iterations' config that you guys removed from v1 to v2 (but left in the examples).  
It will once again kill the worker thread after the amount of iterations have passed.  
when iterations is 0 the killing of phantomjs is disabled, so maybe you could set the iterations config to 0 by default in server.js instead of 10 (which wasn't doing anything right now) so that this feature is also disabled by default...

I also started using SIGKILL to kill the worker, which seems to avoid having phantomjs process stay around.

and preventing the rotating port that's based on the worker.id to rotate above 200 with a modulo.