### PR TITLE
added a 404 status code when page was not found

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -262,6 +262,10 @@ server.onResourceReceived = function (req, res, response) {
             req.prerender.statusCode = response.status;
         }
     }
+
+	if (!req.prerender.statusCode) {
+		req.prerender.statusCode = 404;
+	}
 };
 
 // Decrement the number of pending requests to download when there's a timeout


### PR DESCRIPTION
Before, when requesting for example the url 'http://www.idonotexist1234567890.com', it would return status code 200. This PR changes that to a 404 not found