### PR TITLE
Delete s3 cache upon DELETE request

### DIFF
--- a/lib/plugins/s3HtmlCache.js
+++ b/lib/plugins/s3HtmlCache.js
@@ -9,6 +9,18 @@ module.exports = {
     },
 
     beforePhantomRequest: function(req, res, next) {
+        if(req.method === 'DELETE') {
+            this.cache.del(req.prerender.url, function(err, result) {
+                if (!err && result) {
+                    console.log('cache delete');
+                    res.send(200, result.Body);
+                } else {
+                    console.log('cache delete failed');
+                }
+            });
+            return;
+        }
+
         if(req.method !== 'GET') {
             return next();
         }
@@ -55,5 +67,14 @@ var s3_cache = {
         if (!callback) {
             request.send();
         }
+    },
+    del: function(key, callback) {
+        if (process.env.S3_PREFIX_KEY) {
+            key = process.env.S3_PREFIX_KEY + '/' + key;
+        }
+
+        s3.deleteObject({
+            Key: key
+        }, callback);
     }
 };


### PR DESCRIPTION
This is useful in case you want to clear a bunch of pages, but recomputing all at once would overload your server.