### PR TITLE
Pass blocked request resource list from outside. so the resources need to be blocked is configuarable

### DIFF
--- a/lib/resources/blocked-resources.json
+++ b/lib/resources/blocked-resources.json
@@ -1,0 +1,4 @@
+["google-analytics.com", "api.mixpanel.com", "fonts.googleapis.com", "stats.g.doubleclick.net",
+"mc.yandex.ru", "use.typekit.net", "beacon.tapfiliate.com", "js-agent.newrelic.com", "api.segment.io",
+"woopra.com", ".ttf", "static.olark.com", "static.getclicky.com", "fast.fonts.com", "youtube.com\/embed",
+"cdn.heapanalytics.com", "googleads.g.doubleclick.net", "pagead2.googlesyndication.com"]

--- a/lib/server.js
+++ b/lib/server.js
@@ -182,7 +182,7 @@ server.onPhantomPageCreate = function(req, res) {
 server.onResourceRequested = function (requestData, request, blockedResources) {
     for(var i = 0,l = blockedResources.length; i < l; i++) {
         var regex = new RegExp(blockedResources[i], 'gi');
-        if(regex.text(requestData.url)) {
+        if(regex.test(requestData.url)) {
             request.abort();
             requestData.aborted = true;
             break;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,8 @@
 var phantom = require('phantom')
   , _ = require('lodash')
   , util = require('./util.js')
-  , zlib = require('zlib');
+  , zlib = require('zlib')
+  , blockedResources = require('./resources/blocked-resources.json');
 
 var COOKIES_ENABLED = process.env.COOKIES_ENABLED || false;
 
@@ -146,7 +147,7 @@ server.onPhantomPageCreate = function(req, res) {
     this.phantom.set('cookiesEnabled', (req.prerender.cookiesEnabled || _this.options.cookiesEnabled || COOKIES_ENABLED));
 
     // Listen for updates on resource downloads
-    req.prerender.page.onResourceRequested(this.onResourceRequested, _.bind(_this.onResourceRequestedCallback, _this, req, res));
+    req.prerender.page.onResourceRequested(this.onResourceRequested, _.bind(_this.onResourceRequestedCallback, _this, req, res), blockedResources);
     req.prerender.page.set('onResourceReceived', _.bind(_this.onResourceReceived, _this, req, res));
     req.prerender.page.set('onResourceTimeout', _.bind(_this.onResourceTimeout, _this, req, res));
 
@@ -175,68 +176,24 @@ server.onPhantomPageCreate = function(req, res) {
     });
 };
 
-//We want to abort the request if it's a call to Google Analytics or other tracking services.
 /*
- * CODE DUPLICATION ALERT
- * Anything added to this if block has to be added to the if block
- * in server.onResourceRequestedCallback.
- * This if statment cannot be broken out into a helper method because
- * this method is serialized across the network to PhantomJS :(
- * Also, PhantomJS doesn't call onResourceError for an aborted request
+ * Note: PhantomJS doesn't call onResourceError for an aborted request
  */
-server.onResourceRequested = function (requestData, request) {
-    if ((/google-analytics.com/gi).test(requestData.url) ||
-        (/api.mixpanel.com/gi).test(requestData.url) ||
-        (/fonts.googleapis.com/gi).test(requestData.url) ||
-        (/stats.g.doubleclick.net/gi).test(requestData.url) ||
-        (/mc.yandex.ru/gi).test(requestData.url) ||
-        (/use.typekit.net/gi).test(requestData.url) ||
-        (/beacon.tapfiliate.com/gi).test(requestData.url) ||
-        (/js-agent.newrelic.com/gi).test(requestData.url) ||
-        (/api.segment.io/gi).test(requestData.url) ||
-        (/woopra.com/gi).test(requestData.url) ||
-        (/.ttf/gi).test(requestData.url) ||
-        (/static.olark.com/gi).test(requestData.url) ||
-        (/static.getclicky.com/gi).test(requestData.url) ||
-        (/fast.fonts.com/gi).test(requestData.url) ||
-        (/youtube.com\/embed/gi).test(requestData.url) ||
-        (/cdn.heapanalytics.com/gi).test(requestData.url) ||
-        (/googleads.g.doubleclick.net/gi).test(requestData.url) ||
-        (/pagead2.googlesyndication.com/gi).test(requestData.url)) {
-
-        request.abort();
+server.onResourceRequested = function (requestData, request, blockedResources) {
+    for(var i = 0,l = blockedResources.length; i < l; i++) {
+        var regex = new RegExp(blockedResources[i], 'gi');
+        if(regex.text(requestData.url)) {
+            request.abort();
+            requestData.aborted = true;
+            break;
+        }
     }
 };
 
 // Increment the number of pending requests left to download when a new
 // resource is requested
-/*
- * CODE DUPLICATION ALERT
- * Anything added to this if block has to be added to the if block
- * in server.onResourceRequested.
- * The if statment in onResourceRequested cannot be broken out into a helper method because
- * that method is serialized across the network to PhantomJS :(
- */
 server.onResourceRequestedCallback = function (req, res, request) {
-    if (!(/google-analytics.com/gi).test(request.url) &&
-        !(/api.mixpanel.com/gi).test(request.url) &&
-        !(/fonts.googleapis.com/gi).test(request.url) &&
-        !(/stats.g.doubleclick.net/gi).test(request.url) &&
-        !(/mc.yandex.ru/gi).test(request.url) &&
-        !(/use.typekit.net/gi).test(request.url) &&
-        !(/beacon.tapfiliate.com/gi).test(request.url) &&
-        !(/js-agent.newrelic.com/gi).test(request.url) &&
-        !(/api.segment.io/gi).test(request.url) &&
-        !(/woopra.com/gi).test(request.url) &&
-        !(/.ttf/gi).test(request.url) &&
-        !(/static.olark.com/gi).test(request.url) &&
-        !(/static.getclicky.com/gi).test(request.url) &&
-        !(/fast.fonts.com/gi).test(request.url) &&
-        !(/youtube.com\/embed/gi).test(request.url) &&
-        !(/cdn.heapanalytics.com/gi).test(request.url) &&
-        !(/googleads.g.doubleclick.net/gi).test(request.url) &&
-        !(/pagead2.googlesyndication.com/gi).test(request.url)) {
-
+    if(!request.aborted) {
         req.prerender.pendingRequests++;
     }
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "aws-sdk": "~1.13.0",
     "cache-manager": "0.2.0",
     "lodash": "~2.4.0",
-    "phantom": "~0.5.7",
+    "phantom": "~0.7.2",
     "phantomjs": "~1.9.7-1"
   },
   "bin": {


### PR DESCRIPTION
With my pull request to `phantom`: https://github.com/sgentle/phantomjs-node/pull/229

Passing a variable to `onResourceRequested` can be done now.

See this note in `phantom`:

* onResourceRequested takes a function that executes in the scope of phantom which has access to request.abort(), request.changeUrl(url), and request.setHeader(key,value). The second argument is the callback which can execute in the scope of your code, with access to just the requestData. This function can apply extra arguments which can be passed into the first function e.g.

  ```
page.onResourceRequested(
    function(requestData, request, arg1, arg2) { request.abort(); },
    function(requestData) { console.log(requestData.url) },
    arg1, arg2
);
```

So I create a json file which include all resources need to be blocked, then pass it into `onResourceRequest`.