### PR TITLE
prerender can now bind to a specific interface using NODE_HOSTNAME

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ var cluster = require('cluster')
 // worker cluster process
 exports = module.exports = function(options) {
     var port = options.port || process.env.PORT || 3000;
+    var hostname = options.hostname || process.env.NODE_HOSTNAME || undefined;
 
     if(!options.phantomBasePort) {
         options.phantomBasePort = process.env.PHANTOM_CLUSTER_BASE_PORT || 12300;
@@ -35,7 +36,7 @@ exports = module.exports = function(options) {
     } else {
         var httpServer = http.createServer(_.bind(server.onRequest, server));
 
-        httpServer.listen(port, function () {
+        httpServer.listen(port, hostname, function () {
             util.log('Server running on port ' + port);
         });
     }


### PR DESCRIPTION
As proposed in #164 this could be useful for security/obfuscation reasons, without needing to use a firewall setting.