### PR TITLE
Added custom header for Prerender requests

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -166,6 +166,8 @@ server.onPhantomPageCreate = function(req, res) {
     req.prerender.page.set('onInitialized', function(){
       if(!process.env.DISABLE_INJECTION && req.prerender.page) req.prerender.page.injectJs('bind.js');
     });
+    
+    req.prerender.page.set('customHeaders', { 'X-Prerender-Request': '1' });
 
     req.prerender.page.get('settings.userAgent', function(userAgent) {
         req.prerender.page.set('settings.userAgent', userAgent + ' Prerender (+https://github.com/prerender/prerender)');


### PR DESCRIPTION
It can be undesirable (or impossible) to check for "Prerender" in the `User-Agent` header in some environments. For example, AWS CloudFront can use headers as part of the cache strategy, but caching a different version for every User-Agent string is inefficient and generally unnecessary.

This PR adds a custom header to all requests from Prerender so that they can be identified more easily. This should have no effect on existing behavior.