### PR TITLE
Update customHeaders to identify Prerender requests

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -166,37 +166,41 @@ server.onPhantomPageCreate = function(req, res) {
     req.prerender.page.set('onInitialized', function(){
       if(!process.env.DISABLE_INJECTION && req.prerender.page) req.prerender.page.injectJs('bind.js');
     });
-    
-    req.prerender.page.set('customHeaders', { 'X-Prerender-Request': '1' });
 
-    req.prerender.page.get('settings.userAgent', function(userAgent) {
-        req.prerender.page.set('settings.userAgent', userAgent + ' Prerender (+https://github.com/prerender/prerender)');
+    req.prerender.page.get('customHeaders', function(customHeaders) {
+        customHeaders = customHeaders || {};
+        customHeaders['X-Prerender-Request'] = '1';
+        req.prerender.page.set('customHeaders', customHeaders);
 
-        // Fire off a middleware event, then download all of the assets
-        _this._pluginEvent("onPhantomPageCreate", [_this.phantom, req, res], function() {
-            req.prerender.downloadStarted = req.prerender.lastResourceReceived = new Date();
+        req.prerender.page.get('settings.userAgent', function(userAgent) {
+            req.prerender.page.set('settings.userAgent', userAgent + ' Prerender (+https://github.com/prerender/prerender)');
 
-            req.prerender.downloadChecker = setInterval(function() {
-                _this.checkIfPageIsDoneLoading(req, res, req.prerender.status === 'fail');
-            }, (req.prerender.pageDoneCheckTimeout || _this.options.pageDoneCheckTimeout || PAGE_DONE_CHECK_TIMEOUT));
+            // Fire off a middleware event, then download all of the assets
+            _this._pluginEvent("onPhantomPageCreate", [_this.phantom, req, res], function() {
+                req.prerender.downloadStarted = req.prerender.lastResourceReceived = new Date();
 
-            var uri = req.prerender.url;
+                req.prerender.downloadChecker = setInterval(function() {
+                    _this.checkIfPageIsDoneLoading(req, res, req.prerender.status === 'fail');
+                }, (req.prerender.pageDoneCheckTimeout || _this.options.pageDoneCheckTimeout || PAGE_DONE_CHECK_TIMEOUT));
 
-            /*
-             * phantomjs 1.9.8 handles URL encoding a little differently than phantomjs 2.0
-             * so this fixes that for the short term until everything can be upgraded.
-             */
-            if(!process.env.DISABLE_URI_ENCODE) {
-                uri = encodeURI(uri.replace(/%20/g, ' '));
-            }
+                var uri = req.prerender.url;
 
-            //html5 push state URLs that have an encoded # (%23) need it to stay encoded
-            if(uri.indexOf('#!') === -1) {
-                uri = uri.replace(/#/g, '%23')
-            }
+                /*
+                 * phantomjs 1.9.8 handles URL encoding a little differently than phantomjs 2.0
+                 * so this fixes that for the short term until everything can be upgraded.
+                 */
+                if(!process.env.DISABLE_URI_ENCODE) {
+                    uri = encodeURI(uri.replace(/%20/g, ' '));
+                }
 
-            req.prerender.page.open(uri, function(status) {
-                req.prerender.status = status;
+                //html5 push state URLs that have an encoded # (%23) need it to stay encoded
+                if(uri.indexOf('#!') === -1) {
+                    uri = uri.replace(/#/g, '%23')
+                }
+
+                req.prerender.page.open(uri, function(status) {
+                    req.prerender.status = status;
+                });
             });
         });
     });
@@ -447,7 +451,7 @@ server._send = function(req, res, statusCode, options) {
                 res.setHeader(header.name, header.value);
             });
         }
-        
+
         if (req.prerender.redirectURL && !(_this.options.followRedirect || process.env.FOLLOW_REDIRECT)) {
             res.setHeader('Location', req.prerender.redirectURL);
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -166,6 +166,8 @@ server.onPhantomPageCreate = function(req, res) {
     req.prerender.page.set('onInitialized', function(){
       if(!process.env.DISABLE_INJECTION && req.prerender.page) req.prerender.page.injectJs('bind.js');
     });
+    
+    req.prerender.page.set('customHeaders', { 'X-Prerender-Request': '1' });
 
     req.prerender.page.get('settings.userAgent', function(userAgent) {
         req.prerender.page.set('settings.userAgent', userAgent + ' Prerender (+https://github.com/prerender/prerender)');


### PR DESCRIPTION
This is very similar to https://github.com/prerender/prerender/pull/182, but instead of overwriting `customHeaders`, this fetches them first, and then updates them.

This is safer because existing custom headers won't be clobbered. It's a little more complex though, because of the callback required to fetch the existing headers.