### PR TITLE
process.env.GZIP_MIN_LENGTH

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -452,7 +452,12 @@ server._send = function(req, res, statusCode, options) {
 
         res.setHeader('Content-Type', 'text/html;charset=UTF-8');
 
-        if(req.headers['accept-encoding'] && req.headers['accept-encoding'].indexOf('gzip') >= 0) {
+        var length = 0;
+        if (req.prerender.documentHTML) {
+            length = Buffer.isBuffer(req.prerender.documentHTML) ? req.prerender.documentHTML.length : Buffer.byteLength(req.prerender.documentHTML, 'utf8');
+        }
+
+        if(req.headers['accept-encoding'] && length >= ( process.env.GZIP_MIN_LENGTH || 0 ) && req.headers['accept-encoding'].indexOf('gzip') >= 0) {
             res.setHeader('Content-Encoding', 'gzip');
             zlib.gzip(req.prerender.documentHTML, function(err, result) {
                 req.prerender.documentHTML = result;


### PR DESCRIPTION
Gzip a small file (usually minified) may make it bigger. Also, compression is computationally intensive which isn't really the expertise of nodeJS. The default is still 0 only to avoid surprising existing users who are not expecting this change.