### PR TITLE
Allow a plugin to bust the cache to force a reload of the page

### DIFF
--- a/lib/plugins/inMemoryHtmlCache.js
+++ b/lib/plugins/inMemoryHtmlCache.js
@@ -1,4 +1,5 @@
 var cache_manager = require('cache-manager');
+var util = require('../util');
 
 module.exports = {
     init: function() {
@@ -9,7 +10,7 @@ module.exports = {
 
     beforePhantomRequest: function(req, res, next) {
         this.cache.get(req.prerender.url, function (err, result) {
-            if (!err && result) {
+            if (!err && !util.shouldBustCache(req) && result) {
                 res.send(200, result);
             } else {
                 next();

--- a/lib/util.js
+++ b/lib/util.js
@@ -11,16 +11,9 @@ util.normalizeUrl = function (u) {
 
 // Gets the URL to prerender from a request, stripping out unnecessary parts
 util.getUrl = function (req) {
-    var decodedUrl
-      , parts;
+    var parts;
 
-    try {
-        decodedUrl = decodeURIComponent(req.url);
-    } catch (e) {
-        decodedUrl = req.url;
-    }
-
-    parts = url.parse(decodedUrl, true);
+    parts = util.getUrlParts(req);
 
     // Remove the _escaped_fragment_ query parameter
     if (parts.query && parts.query.hasOwnProperty('_escaped_fragment_')) {
@@ -29,9 +22,32 @@ util.getUrl = function (req) {
         delete parts.search;
     }
 
+    // Remove the cache bust parameter, since it has no use to upstream
+    if (parts.query && parts.query.hasOwnProperty('_bust_cache')) delete parts.query['_bust_cache'];
+
     var newUrl = url.format(parts);
     if (newUrl[0] === '/') newUrl = newUrl.substr(1);
     return newUrl;
+};
+
+util.shouldBustCache = function (req) {
+    var parts;
+
+    parts = util.getUrlParts(req);
+
+    return (parts.query && parts.query.hasOwnProperty('_bust_cache'));
+};
+
+util.getUrlParts = function (req) {
+    var decodedUrl
+
+    try {
+        decodedUrl = decodeURIComponent(req.url);
+    } catch (e) {
+        decodedUrl = req.url;
+    }
+
+    return url.parse(decodedUrl, true);
 };
 
 util.log = function() {


### PR DESCRIPTION
Currently plugins can cache pages, but they cant be easily force reloading. This commit adds the feature to bust the cache by simply sending the parameter `_bust_cache` along. This allows your application to request the page directly from prerender, ensuring search crawlers always hit the cache and get served the correct page within a few milliseconds.

Since I'm not very familiar with node (yet), I'd love to hear recommendations to further improve this system.

To explain the rationale of this PR, let me sketch the workflow: In our case clients can update their pages (which happens quite frequently), but Google visits less than once a day. So we cannot just have very short TTL's, but would like to send the prerendered version to Google directly (improving SE). Using this approach, we can let the application fire an event over our message bus to a very small microservice, which will simply call this page with the `_bust_cache=true` parameter, which will set the new content directly in prerender, ready to be served