### PR TITLE
Adds dnodeOpts to disable `weak` option of dnode

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -99,6 +99,10 @@ server.createPhantom = function() {
     if(this.options.onStderr) {
       opts.onStderr = this.options.onStderr;
     }
+    
+    if(this.options.dnodeOpts) {
+      opts.dnodeOpts = this.options.dnodeOpts;
+    }
 
     args.push(opts);
 


### PR DESCRIPTION
fixes Error: Cannot find module 'weak'
see https://github.com/sgentle/phantomjs-node#use-it-in-windows

example:
````javascript
var prerender = require('prerender');
var server = prerender({
    dnodeOpts: { weak: false }
});
server.start();
```