### PR TITLE
Added the ability to skip the cache with httpHeaders

### DIFF
--- a/lib/plugins/httpHeaders.js
+++ b/lib/plugins/httpHeaders.js
@@ -1,5 +1,5 @@
 module.exports = {
-    beforeSend: function(req, res, next) {
+    afterPhantomRequest: function(req, res, next) {
         if(req.prerender.documentHTML) {
             var statusMatch = /<meta[^<>]*(?:name=['"]prerender-status-code['"][^<>]*content=['"]([0-9]{3})['"]|content=['"]([0-9]{3})['"][^<>]*name=['"]prerender-status-code['"])[^<>]*>/i,
                 headerMatch = /<meta[^<>]*(?:name=['"]prerender-header['"][^<>]*content=['"]([^'"]*?): ?([^'"]*?)['"]|content=['"]([^'"]*?): ?([^'"]*?)['"][^<>]*name=['"]prerender-header['"])[^<>]*>/gi,


### PR DESCRIPTION
This pull request resolves #248.
Changed the httpHeaders plugin method from `beforeSend` to `afterPhantomRequest`.
