### PR TITLE
Use HE to decode header values that have already been encoded by Phantom

### DIFF
--- a/lib/plugins/httpHeaders.js
+++ b/lib/plugins/httpHeaders.js
@@ -1,3 +1,5 @@
+var he = require('he');
+
 module.exports = {
     afterPhantomRequest: function(req, res, next) {
         if(req.prerender.documentHTML) {
@@ -13,7 +15,7 @@ module.exports = {
             }
 
             while (match = headerMatch.exec(head)) {
-                res.setHeader(match[1] || match[3], match[2] || match[4]);
+                res.setHeader(match[1] || match[3], he.decode(match[2] || match[4]));
                 req.prerender.documentHTML = req.prerender.documentHTML.toString().replace(match[0], '');
             }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lodash": "^3.1.0",
     "phantom": "^0.7.2",
     "phantomjs": "^1.9.15",
-    "tree-kill": "0.0.6"
+    "tree-kill": "0.0.6",
+    "he": "^0.5.0"
   },
   "devDependencies": {
     "mocha": "~1.13.0",


### PR DESCRIPTION
Phantom URL encodes all URLs in it's output, which isn’t entirely unreasonable, and crawlers and browsers seem to understand this, as long as these URLs are described in markup.
 
Unfortunately this seems to have lead to the assumption in /lib/plugins/httpHeaders.js line 16, that the value in the 'prerender-header’ meta tag is ready to be passed straight out as an HTTP header.

This assumption has lead to, among  other things, ampersands in the query string being encoded as &amp;, and then passed, fully encoded, in to the response headers in situations such as a 301 redirect with the following meta tag being presented in the prerendered document: <meta name="prerender-header" content="http://www.mydomain.com/?query=string&error=maybe" />

The resultant HTTP header is as follows:
`Location: http://www.mydomain.com/?query=string&amp;error=maybe`

The browser then arrives at the page with this invalid query string which can result in undefined behaviour in the target system.

This PR addresses this by using Mathias Bynens' "he" library to reverse the encoding performed by PhantomJS. 

Testing:

I have prepared a test page (http://pinacle8.uatec.net/prerendertest.html), with the following meta tag, which is expected to result in a 301 redirect to the exact URL specified: `<meta name="prerender-header" content="Location: http://somehost/?Key1=Value1&Key2=Value2" />`


