### PR TITLE
Swapped out phantomjs-prebuilt fork with upstream

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -79,7 +79,7 @@ server.createPhantom = function() {
 
     var opts = {
         port: port,
-        binary: process.env.PHANTOMJS_PATH || require('phantomjs').path,
+        binary: process.env.PHANTOMJS_PATH || require('phantomjs-prebuilt').path,
         onExit: function() {
             _this.phantom = null;
             util.log('phantom crashed, restarting...');
@@ -94,7 +94,7 @@ server.createPhantom = function() {
     if(this.options.onStderr) {
       opts.onStderr = this.options.onStderr;
     }
-    
+
     if(this.options.dnodeOpts) {
       opts.dnodeOpts = this.options.dnodeOpts;
     }
@@ -433,7 +433,7 @@ server._send = function(req, res, statusCode, options) {
                 res.setHeader(header.name, header.value);
             });
         }
-        
+
         if (req.prerender.redirectURL && !(_this.options.followRedirect || process.env.FOLLOW_REDIRECT)) {
             res.setHeader('Location', req.prerender.redirectURL);
         }
@@ -474,7 +474,7 @@ server._sendResponse = function(req, res, options) {
     //getting 502s for sites that return these headers
     res.removeHeader('X-Content-Security-Policy');
     res.removeHeader('Content-Security-Policy');
-    
+
     res.writeHead(req.prerender.statusCode || 504);
 
     if (req.prerender.documentHTML) res.write(req.prerender.documentHTML);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cache-manager": "^0.16.0",
     "lodash": "^3.1.0",
     "phantom": "^0.7.2",
-    "phantomjs": "git+https://github.com/thoop/phantomjs.git#14387f2fe27b0bbc2df097af1c0cb53876cd70a2",
+    "phantomjs-prebuilt": "2.1.3",
     "tree-kill": "0.0.6",
     "he": "^0.5.0"
   },


### PR DESCRIPTION
Was struggling to build a prerender service on linux due to 2.0.0 binary not existing. Managed to get it working by referencing a newer version of phantomjs-prebuilt. Got a feeling that I'm missing something here but figured if I put it on the table, you'll at least let me know what it'll take to achieve this :)