### PR TITLE
Clone phantom arguments on create so that they are preserved on resta…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 4.0.6 - 2016-03-09
 ### Changed
-- preserver phantom arguments when server is restarting
+- preserve phantom arguments when server is restarting
+- use default when phantomArguments is empty
 
 ## 4.0.5 - 2016-02-29
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.0.6 - 2016-03-09
+### Changed
+- preserver phantom arguments when server is restarting
+
 ## 4.0.5 - 2016-02-29
 ### Changed
 - prevent multiple phantomjs instances from being started with low number of iterations

--- a/lib/server.js
+++ b/lib/server.js
@@ -69,7 +69,7 @@ server.createPhantom = function() {
 
     var args = {'--load-images': false, '--ignore-ssl-errors': true, '--ssl-protocol': 'tlsv1.2'};
 
-    if(this.options.phantomArguments) {
+    if(this.options.phantomArguments && !_.isEmpty(this.options.phantomArguments)) {
         args = _.clone(this.options.phantomArguments);
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -70,7 +70,7 @@ server.createPhantom = function() {
     var args = {'--load-images': false, '--ignore-ssl-errors': true, '--ssl-protocol': 'tlsv1.2'};
 
     if(this.options.phantomArguments) {
-        args = this.options.phantomArguments;
+        args = _.clone(this.options.phantomArguments);
     }
 
     util.log('starting phantom...');
@@ -82,7 +82,7 @@ server.createPhantom = function() {
     if(this.options.onStderr) {
       phridge.config.stderr = this.options.onStderr;
     }
-    
+
     phridge.spawn(args).then(_.bind(_this.onPhantomCreate, _this));
 };
 
@@ -466,7 +466,7 @@ server._send = function(req, res, statusCode, options) {
                 }
             });
         }
-        
+
         if (req.prerender.redirectURL && !(_this.options.followRedirect || process.env.FOLLOW_REDIRECT)) {
             res.setHeader('Location', req.prerender.redirectURL);
         }
@@ -507,7 +507,7 @@ server._sendResponse = function(req, res, options) {
     //getting 502s for sites that return these headers
     res.removeHeader('X-Content-Security-Policy');
     res.removeHeader('Content-Security-Policy');
-    
+
     res.writeHead(req.prerender.statusCode || 504);
 
     if (req.prerender.documentHTML) res.write(req.prerender.documentHTML);
@@ -530,7 +530,7 @@ server._killPhantomJS = function() {
         _this.phantom = null;
         process.nextTick(_.bind(_this.createPhantom, _this));
     }
-    
+
     if (_this.phantom === null) {
       return;
     }
@@ -552,7 +552,7 @@ server._disposeAll = function(callback) {
 
         if(!disposed) {
             console.log('unable to dispose PhantomJS. Forcing kill...');
-        
+
             try {
                 process.kill(_this.phantomPid, 'SIGKILL');
             } catch(e) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Prerender.io",
   "name": "prerender",
   "description": "Service to prerender Javascript rendered pages for SEO",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
this.options.phantomArguments is passed by reference to phridge spawn which will empty it. So whenever the phantom instance is restarted the args object will be empty. Please merge this asap because we cannot use web-security flag in order to ignore SSL handshake failures.