### PR TITLE
Clear memory cache on page disposing

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -431,12 +431,27 @@ server.clearLocalStorage = function(req, res) {
     });
 };
 
+server.clearMemoryCache = function(req, res) {
+    if(!req.prerender.page) {
+        return;
+    }
+
+    req.prerender.page.run(function() {
+        try {
+            if(this.clearMemoryCache && typeof this.clearMemoryCache == 'function') {
+                this.clearMemoryCache();
+            }
+        } catch (e) {}
+    });
+};
+
 server._send = function(req, res, statusCode, options) {
     var _this = this;
 
     if(req.prerender.page) {
 
         this.clearLocalStorage(req, res);
+        this.clearMemoryCache(req, res);
         req.prerender.page.dispose().then(function() {
             req.prerender.page = null;
         });


### PR DESCRIPTION
In some cases prerender generates empty page on 304 server respond.
There is clearing of localStorage before disposing phantom's page
in `server._send`, but it is necessary to clear memory cache too in
order to avoid this.

There is a function [clearMemoryCache()](https://github.com/ariya/phantomjs/commit/5768b705a0) in PhantomJS, which allows to clear memory cache.

I found only one different approach to clear memory cache - killing PhantomJS, like it was done in  [prerender-clear-local-storage plugin](/hightail/prerender-clear-local-storage/blob/master/lib/clear-local-storage.js#L108). 

Hope, suggested method using clearMemoryCache() function is more appropriate.