### PR TITLE
Fix exception on node 6.x

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -34,7 +34,7 @@ util.getUrl = function (req) {
     parts = url.parse(decodedUrl, true);
 
     // Remove the _escaped_fragment_ query parameter
-    if (parts.query && parts.query.hasOwnProperty('_escaped_fragment_')) {
+    if (parts.query && Object.prototype.hasOwnProperty.call(parts.query, '_escaped_fragment_')) {
         
         if (parts.query['_escaped_fragment_'] && !Array.isArray(parts.query['_escaped_fragment_'])) {
             parts.hash = '#!' + parts.query['_escaped_fragment_'];


### PR DESCRIPTION
After updating to nodejs v6.x I'm getting `TypeError: parts.query.hasOwnProperty is not a function` exception.