### PR TITLE
Url encode filename

### DIFF
--- a/lib/plugins/s3HtmlCache.js
+++ b/lib/plugins/s3HtmlCache.js
@@ -41,6 +41,7 @@ module.exports = {
 
 var s3_cache = {
     get: function(key, callback) {
+        key = encodeURIComponent(key);
         if (process.env.S3_PREFIX_KEY) {
             key = process.env.S3_PREFIX_KEY + '/' + key;
         }
@@ -50,6 +51,7 @@ var s3_cache = {
         }, callback);
     },
     set: function(key, value, callback) {
+        key = encodeURIComponent(key);
         if (process.env.S3_PREFIX_KEY) {
             key = process.env.S3_PREFIX_KEY + '/' + key;
         }


### PR DESCRIPTION
Encode filename to avoid problems with url encoding on S3 getObject/pubOject actions.
This fixes the Error { NoSuchKey: The specified key does not exist }.

A side effect is to have all the cache files in the same folder and maybe it is ugly for someone, but it is not a technical limitation.