### PR TITLE
Enable redis cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.3.0 - 2016-08-04
+### Changed
+- Bumped all dependency versions to latest
+
 ## 4.2.0 - 2016-08-04
 ### Added
 - Added ability for cluster master to kill last known phantomjs pid for a worker if the worker dies (preventing orphaned phantomjs instances)

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "he": "^1.1.0",
     "lodash": "^4.14.1",
     "phridge": "^2.0.0",
+    "prerender-redis-cache": "^0.1.6",
     "signal-exit": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Prerender.io",
   "name": "prerender",
   "description": "Service to prerender Javascript rendered pages for SEO",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -16,5 +16,6 @@ server.use(prerender.removeScriptTags());
 server.use(prerender.httpHeaders());
 // server.use(prerender.inMemoryHtmlCache());
 // server.use(prerender.s3HtmlCache());
+server.use(require('prerender-redis-cache'));
 
 server.start();


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/131587237

This will make prerender only re-render a page once per day, which should be fine for search engine purchases. This way, even if the middleware is forwarding all requests, it would not result in all those requests coming back to the application and being rendered.