### PR TITLE
Resolve 404 when appending the link with ?_escaped_fragment_

### DIFF
--- a/lib/plugins/httpHeaders.js
+++ b/lib/plugins/httpHeaders.js
@@ -11,6 +11,7 @@ module.exports = {
 
             if (match = statusMatch.exec(head)) {
                 statusCode = match[1] || match[2];
+                req.prerender.statusCode = statusCode;
                 req.prerender.documentHTML = req.prerender.documentHTML.toString().replace(match[0], '');
             }
 


### PR DESCRIPTION
Prerender was always returning 404 when appending the escaped fragment to the end of the link
even when the prerender-status-code in the page is 200
so what this line do is overwriting the status code of the page with prerender-status-code if it contain it