### PR TITLE
Added navegg(navdmp.com) to blocked list for analytics

### DIFF
--- a/lib/resources/blocked-resources.json
+++ b/lib/resources/blocked-resources.json
@@ -25,5 +25,8 @@
 	"hn.inspectlet.com",
 	"tpc.googlesyndication.com",
 	"partner.googleadservices.com",
-	"\\.woff"
+	"\\.woff",
+	"cdn.navdmp.com",
+	"usr.navdmp.com",
+	"sync.navdmp.com"
 ]


### PR DESCRIPTION
Added Navegg (navegg.com) to prevent polluting its analytics.