### PR TITLE
Enable health check requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,19 @@ server.start();
 
 Number of milliseconds between executing the javascript on the webpage to pull off the HTML. Pulling off the HTML only happens multiple times when `window.prerenderReady` is set to false. You can also set the environment variable of `EVALUATE_JAVASCRIPT_CHECK_TIMEOUT` instead of passing in the `evaluateJavascriptCheckTimeout` parameter. `Default: 300`
 
+### enableHealthCheckRequests
+```
+var prerender = require('./lib');
+
+var server = prerender({
+    enableHealthCheckRequests: true
+});
+
+server.start();
+```
+
+Enable successful responses with a status code of 200 for requests that do not include a URL to be rendered. For example `GET http://service.prerender.io/` instead of something like `GET http://service.prerender.io/https://www.google.com`. This allows for easy configuration of health check services that will not work with the default 404 response to these requests. You can also set the environment variable of `ENABLE_HEALTH_CHECK_REQUESTS` instead of passing in the `enableHealthCheckRequests` parameter. `Default: false`
+
 ## Plugins
 
 We use a plugin system in the same way that Connect and Express use middleware. Our plugins are a little different and we don't want to confuse the prerender plugins with the [prerender middleware](#middleware), so we opted to call them "plugins".

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ var server = prerender({
 server.start();
 ```
 
-Enable successful responses with a status code of 200 for requests that do not include a URL to be rendered. For example `GET http://service.prerender.io/` instead of something like `GET http://service.prerender.io/https://www.google.com`. This allows for easy configuration of health check services that will not work with the default 404 response to these requests. You can also set the environment variable of `ENABLE_HEALTH_CHECK_REQUESTS` instead of passing in the `enableHealthCheckRequests` parameter. `Default: false`
+Enable successful responses with a status code of 200 for requests that do not include a URL to be rendered. For example `GET http://service.prerender.io/` instead of something like `GET http://service.prerender.io/https://www.google.com`. This allows for easy configuration of health check services that will not work with the default 5XX response to these requests. You can also set the environment variable of `ENABLE_HEALTH_CHECK_REQUESTS` instead of passing in the `enableHealthCheckRequests` parameter. `Default: false`
 
 ## Plugins
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -24,6 +24,8 @@ var NUM_ITERATIONS = process.env.NUM_ITERATIONS || 40;
 
 var NUM_SOFT_ITERATIONS = process.env.NUM_SOFT_ITERATIONS || 30;
 
+var ENABLE_HEALTH_CHECK_REQUESTS = process.env.ENABLE_HEALTH_CHECK_REQUESTS || false;
+
 var server = exports = module.exports = {};
 
 server.init = function(options) {
@@ -121,6 +123,14 @@ server.onRequest = function(req, res) {
         url: util.getUrl(req),
         start: new Date()
     };
+
+    if (_this.options.enableHealthCheckRequests || ENABLE_HEALTH_CHECK_REQUESTS) {
+        if (!req.prerender.url || req.prerender.url.split('//').length < 2) {
+            req.prerender.documentHTML = "SUCCESS";
+            res.send(200);
+            return;
+        }
+    }
 
     util.log('getting', req.prerender.url);
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -126,6 +126,7 @@ server.onRequest = function(req, res) {
 
     if (_this.options.enableHealthCheckRequests || ENABLE_HEALTH_CHECK_REQUESTS) {
         if (!req.prerender.url || req.prerender.url.split('//').length < 2) {
+            util.log('responding to health check');
             req.prerender.documentHTML = "SUCCESS";
             res.send(200);
             return;


### PR DESCRIPTION
Enable successful responses with a status code of 200 for requests that do not include a URL to be rendered. For example `GET http://service.prerender.io/` instead of something like `GET http://service.prerender.io/https://www.google.com`. This allows for easy configuration of health check services that will not work with the default 5XX response to these requests. Can be enabled in the server options or an environment variable.