### PR TITLE
Block intercom from loading

### DIFF
--- a/lib/plugins/blockResources.js
+++ b/lib/plugins/blockResources.js
@@ -22,6 +22,7 @@ const blockedResources = [
 	"hn.inspectlet.com",
 	"tpc.googlesyndication.com",
 	"partner.googleadservices.com",
+        "widget.intercom.io",
 	".ttf",
 	".eot",
 	".otf",


### PR DESCRIPTION
Intercom loads a whole lot of CSS inline, and is relatively slow to load. As Intercom does not really improve SEO it might be useful to block these resources from loading