### PR TITLE
Adding the in memory cache back for chrome headless.

### DIFF
--- a/lib/plugins/inMemoryHtmlCache.js
+++ b/lib/plugins/inMemoryHtmlCache.js
@@ -1,0 +1,31 @@
+var cacheManager = require('cache-manager');
+
+module.exports = {
+    init: function() {
+        this.cache = cacheManager.caching({
+            store: 'memory', max: process.env.CACHE_MAXSIZE || 100, ttl: process.env.CACHE_TTL || 60/*seconds*/
+        });
+    },
+
+    requestReceived: function(req, res, next) {
+        this.cache.get(req.prerender.url, function (err, result) {
+            if (!err && result) {
+                console.log('sending cached copy of ', req.prerender.url)
+                req.prerender.responseSent = true;
+                req.prerender.fileSystemCached = true;
+                res.send(200, result);
+                return next();
+            } else {
+                next();
+            }
+        });
+    },
+
+    pageLoaded: function(req, res, next) {
+        if (!req.prerender.fileSystemCached) {
+            console.log('saving to cache', req.prerender.url);
+            this.cache.set(req.prerender.url, req.prerender.content);
+        }
+        next();
+    }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "body-parser": "~1.18.2",
+    "cache-manager": "^2.6.0",
     "chrome-remote-interface": "~0.24.2",
     "compression": "~1.7.1",
     "express": "~4.16.2",


### PR DESCRIPTION
Addressing issue #469 adding the in memory cache back using chrome headless events.  Doesn't intercept all requests after the initial page request but does use in memory cache for the initial request which is where most of the processing overhead is on a SPA anyhow.  Usage like

`server.js`
```
server.use(prerender.inMemoryHtmlCache());
```

