### PR TITLE
Updated README.md to add prerender-mongodb-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ Caches pages in memory. Available at [coming soon](https://github.com/prerender/
 
 Caches pages in S3. Available at [coming soon](https://github.com/prerender/prerender)
 
+### mongo-db-cache
+
+Caches pages in MongoDB. Available at [prerender-mongodb-cache](https://github.com/MartinVandersteen/prerender-mongodb-cache)
+
 --------------------
 
 ### <a id='prerendercom'></a>


### PR DESCRIPTION
Just updated the old prerender-mongodb-cache plugin that was working on prerender's PhantomJS version so that it works on the new version. It is not based on [lammertw's version](https://github.com/lammertw/prerender-mongodb-cache) but rather on [YouriT's](https://github.com/YouriT/prerender-mongodb-cache) which added the ability to set a TTL for the cached pages to expire.

Don't hesitate to give it a look and merge the modification in if you think its useful :) I'm using it on production right now and figured it might be nice to add it to the main repository's README!