### PR TITLE
fix chrome.kill for cases when no chromeChild is defined

### DIFF
--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -36,7 +36,9 @@ chrome.onClose = function(callback) {
 
 
 chrome.kill = function() {
-	this.chromeChild.kill('SIGINT');
+	if (this.chromeChild) {
+		this.chromeChild.kill('SIGINT');
+	}
 };
 
 


### PR DESCRIPTION
In case no Chrome install can be found, chromeChild is never defined, which was making the chrome.kill function crash