### PR TITLE
Allow passing options to express

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,9 +10,9 @@ const bodyParser = require('body-parser');
 const compression = require('compression');
 
 exports = module.exports = (options = {}) => {
-  const parsedOptions = Object.assign({}, {
-    port: options.port || process.env.PORT || 3000
-  }, options)
+	const parsedOptions = Object.assign({}, {		
+		port: options.port || process.env.PORT || 3000
+	}, options)
 
 	server.init(options);
 	server.onRequest = server.onRequest.bind(server);
@@ -25,7 +25,7 @@ exports = module.exports = (options = {}) => {
 	//dont check content-type and just always try to parse body as json
 	app.post('*', bodyParser.json({ type: () => true }), server.onRequest);
 
-	app.listen(parsedOptions, () => util.log(`Prerender server accepting requests on port ${port}`))
+	app.listen(parsedOptions, () => util.log(`Prerender server accepting requests on port ${parsedOptions.port}`))
 
 	return server;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,9 @@ const bodyParser = require('body-parser');
 const compression = require('compression');
 
 exports = module.exports = (options = {}) => {
-	const port = options.port || process.env.PORT || 3000;
+  const parsedOptions = Object.assign({}, {
+    port: options.port || process.env.PORT || 3000
+  }, options)
 
 	server.init(options);
 	server.onRequest = server.onRequest.bind(server);
@@ -23,7 +25,7 @@ exports = module.exports = (options = {}) => {
 	//dont check content-type and just always try to parse body as json
 	app.post('*', bodyParser.json({ type: () => true }), server.onRequest);
 
-	app.listen(port, () => util.log(`Prerender server accepting requests on port ${port}`))
+	app.listen(parsedOptions, () => util.log(`Prerender server accepting requests on port ${port}`))
 
 	return server;
 };


### PR DESCRIPTION
We need it in order to set a host to express for security reasons.

I think it could be useful for other purposes of other options ...