### PR TITLE
Add plugin to remove style and AngularJS directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Looking for our PhantomJS Prerender server? [Go to our phantomjs branch](https:/
 $ npm install prerender
 ```
 ##### server.js
+
 ```js
 const prerender = require('prerender');
 const server = prerender();
@@ -19,6 +20,32 @@ server.start();
 ##### test it:
 ```bash
 curl http://localhost:3000/render?url=https://www.example.com/
+```
+To render a page programmatically:
+```js
+var local = require('./local.js');
+local({
+    url: 'https://google.com',
+    output: {
+        type: 'file',
+        path: './test.html'
+    },
+    plugins:[
+        'blacklist',
+        'whitelist',
+        'blockResources',
+        'httpHeaders',
+        'sendPrerenderHeader',
+        'basicAuth',
+        'removeAngularjs',
+        'removeScriptTags',
+        'removeStyle',
+    ],
+    chromeLocation: '/usr/bin/chromium',
+    pageLoadTimeout: 10 * 1000,
+    waitAfterLastRequest: 10 * 1000,
+    followRedirects: true
+});
 ```
 
 ## Use Cases

--- a/lib/plugins/removeAngularjs.js
+++ b/lib/plugins/removeAngularjs.js
@@ -1,0 +1,53 @@
+/**
+ * Remove Angular tags
+ * 
+ * Some tags are used in Angularjs and is not useful in the SEO. For example the
+ * following DIV
+ * 
+ * <div ng-if="ctrl.isPartEnable()">Hi</div>
+ * 
+ * is equal to:
+ * 
+ * <div>Hi</div>
+ * 
+ * This plagin remove Angularjs tags.
+ * 
+ * @see https://docs.angularjs.org/api/ng/directive
+ * @author Mostafa Barmshory(mostafa.barmshory@gmail.com)
+ */
+module.exports = {
+        pageLoaded: (req, res, next) => {
+            if (!req.prerender.content || req.prerender.renderType != 'html') {
+                return next();
+            }
+
+            var content = req.prerender.content.toString();
+            var matches = null;
+            var patterns = [
+                // move to angular
+                /(\s)+ng-(?:[^=]+)=\"(?:[^\"]*)\"/gim,
+                /(\s)+data-ng-(?:[^=]+)=\"(?:[^\"]*)\"/gim,
+                /(\s)+transclude=\"(?:[^\"]*)\"/gim,
+                /<!--(\s)*ng(?:\w+)\:((?!-->).)*-->/gi,
+                /<!--(\s)*end ng(?:\w+)\:((?!-->).)*-->/gi,
+                
+                // move to angular-material design
+                /(\s)+md-(?:[^=]+)=\"(?:[^\"]*)\"/gim,
+                /(\s)+data-md-(?:[^=]+)=\"(?:[^\"]*)\"/gim,
+                /(\s)+layout=\"(?:[^\"]*)\"/gim,
+                /(\s)+layout-(?:[^=]+)=\"(?:[^\"]*)\"/gim,
+                /(\s)+flex=\"(?:[^\"]*)\"/gim,
+                /(\s)+flex-(?:[^=]+)=\"(?:[^\"]*)\"/gim,
+                ];
+
+            for(let j = 0; j < patterns.length; j++){
+                matches = content.match(patterns[j]);
+                for (let i = 0; matches && i < matches.length; i++) {
+                    content = content.replace(matches[i], '');
+                }
+            }
+
+            req.prerender.content = content;
+            next();
+        }
+};

--- a/lib/plugins/removeStyle.js
+++ b/lib/plugins/removeStyle.js
@@ -1,0 +1,43 @@
+/**
+ * Remove styles
+ * 
+ * Styles are not used in indexing. So it is better to remove and make the page
+ * small.
+ * 
+ * This plagin removes the page styles
+ * 
+ * @author Mostafa Barmshory(mostafa.barmshory@gmail.com)
+ */
+module.exports = {
+        pageLoaded: (req, res, next) => {
+            if (!req.prerender.content || req.prerender.renderType != 'html') {
+                return next();
+            }
+
+            var content = req.prerender.content.toString();
+            var matches = null;
+            var patterns = [
+                /<style(?:.*?)>(?:[\S\s]*?)<\/style>/gim,
+                
+                / class=\"(?:[^\"]*?)\"/gi,
+                / style=\"(?:[^\"]*?)\"/gim,
+                / draggable=\"(?:[^\"]*?)\"/gim,
+                / color=\"(?:[^\"]*?)\"/gim,
+                / tabindex=\"(?:[^\"]*?)\"/gim,
+                / width=\"(?:[^\"]*?)\"/gim,
+                / height=\"(?:[^\"]*?)\"/gim,
+                / size=\"(?:[^\"]*?)\"/gim,
+                / align=\"(?:[^\"]*?)\"/gim,
+                ];
+
+            for(let j = 0; j < patterns.length; j++){
+                matches = content.match(patterns[j]);
+                for (let i = 0; matches && i < matches.length; i++) {
+                    content = content.replace(matches[i], '');
+                }
+            }
+
+            req.prerender.content = content;
+            next();
+        }
+};

--- a/local.js
+++ b/local.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const path = require('path');
+const basename = path.basename;
+const server = require('./lib/server');
+
+/**
+ * Render an URL
+ * 
+ * Render an URL nad store into a file
+ */
+exports = module.exports = function (options = {}) {
+	// Create request
+	var request = new Request(options);
+	var response = new Response(options);
+
+	// render page
+	server.init(options);
+	options.plugins.forEach((plugin) => {
+		if (!/\.js$/.test(plugin)) {
+			return;
+		}
+		var name = basename(plugin, '.js');
+		var module = require('./lib/plugins/' + name);
+		server.use(module);
+	});
+	server.start();
+	server.onRequest(request, response);
+};
+
+
+/**
+ * Create a request
+ * 
+ */
+function Request(options = {}) {
+	if (!options.url) {
+		throw 'URL must be defined.';
+	}
+	this.url = options.url;
+	this.local = options;
+}
+
+function Response(options = {}) {
+	this.header = {};
+	this.options = options;
+}
+Response.prototype.setHeader = function (key, value) {
+	this.header[key] = value;
+};
+Response.prototype.removeHeader = function (key) {
+	// TODO:
+};
+Response.prototype.status = function (status) {
+	this.setHeader('status', status);
+};
+Response.prototype.end = function () {
+	// TODO: result is ready save 
+};
+Response.prototype.send = function (content) {
+	this.content = content;
+	switch (this.options.output.type) {
+		case 'file':
+			this.saveContentToFile();
+			break;
+		// case 'console':
+		default:
+			console.log(this.content);
+	}
+	server.killBrowser();
+};
+Response.prototype.saveContentToFile = function () {
+	return fs.writeFile(this.options.output.path, this.content);
+};


### PR DESCRIPTION
There are many HTML tags which are not used to index a page. For example color of an element does not affect the search result. This plugin removes such attribute and tags:

- color
- draggable
- width
- height
- style

The AngularJS plugin removes directives from the HTML code. Here is a list of them:

- ng-controller|data-ng-controller
- ng-app|data-ng-app
- ng-style
- ng-class
- ...
