### PR TITLE
Allow prerender to be added on existing express server as nested route

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,43 +1,46 @@
 const fs = require('fs');
 const path = require('path');
-const http = require('http');
 const util = require('./util');
-const basename = path.basename;
 const server = require('./server');
 const express = require('express');
-const app = express();
 const bodyParser = require('body-parser');
 const compression = require('compression');
+const basename = path.basename;
 
-exports = module.exports = (options = {}) => {
-	const port = options.port || process.env.PORT || 3000;
+exports = module.exports = (options = {}, router) => {
+    function bindRoutes(router) {
+        router.get('*', server.onRequest);
+        router.post('*', bodyParser.json({type: () => true}), server.onRequest);
+    }
 
-	server.init(options);
-	server.onRequest = server.onRequest.bind(server);
+    function createExpressApp() {
+        const port = options.port || process.env.PORT || 3000;
+        const app = express();
+        app.disable('x-powered-by');
+        app.use(compression());
+        app.listen(port, () => util.log(`Prerender server accepting requests on port ${port}`));
+        return app;
+    }
 
-	app.disable('x-powered-by');
-	app.use(compression());
+    server.init(options);
+    server.onRequest = server.onRequest.bind(server);
 
-	app.get('*', server.onRequest);
+    const app = router ? router : createExpressApp();
+    bindRoutes(app);
 
-	//dont check content-type and just always try to parse body as json
-	app.post('*', bodyParser.json({ type: () => true }), server.onRequest);
-
-	app.listen(port, () => util.log(`Prerender server accepting requests on port ${port}`))
-
-	return server;
+    return server;
 };
 
 fs.readdirSync(__dirname + '/plugins').forEach((filename) => {
-	if (!/\.js$/.test(filename)) return;
+    if (!/\.js$/.test(filename)) return;
 
-	var name = basename(filename, '.js');
+    var name = basename(filename, '.js');
 
-	function load() {
-		return require('./plugins/' + name);
-	};
+    function load() {
+        return require('./plugins/' + name);
+    };
 
-	Object.defineProperty(exports, name, {
-		value: load
-	});
+    Object.defineProperty(exports, name, {
+        value: load
+    });
 });

--- a/server-router.js
+++ b/server-router.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const express = require('express');
+const compression = require('compression');
+const router = express.Router({mergeParams: true});
+const prerender = require('./lib');
+
+// setup express server
+const port = process.env.PORT || 3000;
+const app = express();
+
+app.disable('x-powered-by');
+app.use(compression());
+app.listen(port, () => console.log(`server accepting requests on port ${port}`));
+
+// start prerender server on /prerender nested path
+const server = prerender({}, router);
+app.use('/prerender', router);
+
+server.use(prerender.sendPrerenderHeader());
+server.use(prerender.removeScriptTags());
+server.use(prerender.httpHeaders());
+server.start();


### PR DESCRIPTION
This will allow to add prerender on any existing express server as a nested route using express.Router functionality.

These changes supersede the changes on #549 allowing a more configurable way to start prerender letting the user to configure the express application. @HollyPony 