### PR TITLE
Allow overriding content-type of response

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -318,6 +318,10 @@ server.firePluginEvent = function(methodName, req, res) {
 			res.setHeader(key, value);
 		}
 
+		newRes.setContentType = function(contentType) {
+			if (contentType) req.prerender.contentType = contentType;
+		}
+
 		next = () => {
 			if (done) return;
 
@@ -367,7 +371,9 @@ server._send = function(req, res) {
 		});
 	}
 
-	if (req.prerender.prerenderData) {
+	if (req.prerender.contentType) {
+		res.setHeader('Content-Type', req.prerender.contentType);
+	} else if (req.prerender.prerenderData) {
 		res.setHeader('Content-Type', 'application/json');
 	} else {
 		res.setHeader('Content-Type', contentTypes[req.prerender.renderType] || 'text/html;charset=UTF-8');


### PR DESCRIPTION
My team is beginning to use Prerender in a production environment, and a couple of things we need to support are health and metrics endpoints. I was able to add the endpoints as plugins, but couldn't properly set the content type of the response because any Content-Type header set in a plugin ultimately gets overwritten in the `server._send` method.

This proposed change adds a `setContentType` method to the response object exposed to plugins, that will take precedence if set.

For some background about my team's use case here: we need to send the response to the health endpoint as "application/json" (which I'm currently working around by setting the renderType to 'har'), and the response to the metrics endpoint as "text/plain; version=0.0.4; charset=utf-8" (which currently isn't possible, as far as I know).