### PR TITLE
Fix timeouts on redirects

### DIFF
--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -461,7 +461,7 @@ chrome.loadUrlThenWaitForPageLoadEvent = function(tab, url) {
 chrome.checkIfPageIsDoneLoading = function(tab) {
 	return new Promise((resolve, reject) => {
 
-		if(!tab.prerender.domContentEventFired) {
+		if (!(tab.prerender.domContentEventFired || tab.prerender.receivedRedirect)) {
 			return resolve(false);
 		}
 


### PR DESCRIPTION
Hi @thoop , one more PR to send your way. I found that if the requested url redirects, Prerender will wait until the page load timeout (20 sec default) before returning a response. It looks like that's because `chrome.checkIfPageIsDoneLoading` only checks `tab.prerender.domContentEventFired`, which appears to always be false in that case. Adding a check for `tab.prerender.receivedRedirect` appears to fix this issue in my testing so far.

This can be reproduced by running Prerender locally, then hitting http://localhost:3000/https://google.com (which redirects to https://www.google.com ).