### PR TITLE
plugins/blockResources: Block direct access as well

### DIFF
--- a/lib/plugins/blockResources.js
+++ b/lib/plugins/blockResources.js
@@ -36,17 +36,19 @@ const blockedResources = [
 	".svg"
 ];
 
+function shouldBlockUrl(url) {
+	let shouldBlock = false;
+	blockedResources.forEach((substring) => {
+		if (url.indexOf(substring) >= 0) {
+			shouldBlock = true;
+		}
+	});
+	return shouldBlock;
+}
+
 module.exports = {
 	requestReceived: (req, res, next) => {
-
-		let shouldBlock = false;
-		blockedResources.forEach((substring) => {
-			if (req.url.indexOf(substring) >= 0) {
-				shouldBlock = true;
-			}
-		});
-
-		if (!shouldBlock) {
+		if (!shouldBlockUrl(req.url)) {
 			next();
 		} else {
 			res.send(403);
@@ -61,16 +63,9 @@ module.exports = {
 
 		req.prerender.tab.Network.requestIntercepted(({interceptionId, request}) => {
 
-			let shouldBlock = false;
-			blockedResources.forEach((substring) => {
-				if (request.url.indexOf(substring) >= 0) {
-					shouldBlock = true;
-				}
-			});
-
 			let interceptOptions = {interceptionId};
 
-			if (shouldBlock) {
+			if (shouldBlockUrl(request.url)) {
 				interceptOptions.errorReason = 'Aborted';
 			}
 

--- a/lib/plugins/blockResources.js
+++ b/lib/plugins/blockResources.js
@@ -37,6 +37,21 @@ const blockedResources = [
 ];
 
 module.exports = {
+	requestReceived: (req, res, next) => {
+
+		let shouldBlock = false;
+		blockedResources.forEach((substring) => {
+			if (req.url.indexOf(substring) >= 0) {
+				shouldBlock = true;
+			}
+		});
+
+		if (!shouldBlock) {
+			next();
+		} else {
+			res.send(403);
+		}
+	},
 	tabCreated: (req, res, next) => {
 		req.prerender.tab.Network.setRequestInterception({
 			patterns: [{urlPattern: '*'}]


### PR DESCRIPTION
In addition to blocking resources as part of loading a page, block direct access of said resources with 403, since otherwise they will just timeout and return 504 instead.