### PR TITLE
Added browserInterceptorCallback and logBrowserRequests

### DIFF
--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -342,6 +342,21 @@ chrome.setUpEvents = function(tab) {
 				}
 			});
 
+			Network.requestIntercepted(({ interceptionId, request }) => {
+				// perform a test against the intercepted request
+				const blocked = this.options.browserInterceptorCallback(request);
+				if (this.options.logBrowserRequests) {
+					util.log(`- ${blocked ? "BLOCK" : "ALLOW"} ${request.url}`);
+				}
+				// decide whether allow or block the request
+				Network.continueInterceptedRequest({
+					interceptionId,
+					errorReason: blocked ? "Aborted" : undefined
+				});
+			});
+
+			Network.setRequestInterception({ patterns: [{ urlPattern: "*" }] });
+
 			Console.messageAdded((params) => {
 				if (tab.prerender.logRequests || this.options.logRequests) {
 					const message = params.message;

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,7 +22,14 @@ const BROWSER_TRY_RESTART_PERIOD = process.env.BROWSER_TRY_RESTART_PERIOD || 600
 
 const server = exports = module.exports = {};
 
-
+/**
+ * Does not block any request when loaded inside the browser
+ * @param request
+ * @returns {boolean}
+ */
+function defaultBrowserInterceptor(request) {
+	return false
+}
 
 server.init = function(options) {
 	this.plugins = this.plugins || [];
@@ -37,6 +44,8 @@ server.init = function(options) {
 	this.options.pdfOptions = this.options.pdfOptions || {
 		printBackground: true
 	};
+	this.options.browserInterceptorCallback = this.options.browserInterceptorCallback || defaultBrowserInterceptor
+	this.options.logBrowserRequests = this.options.logBrowserRequests || false
 
 	this.browser = require('./browsers/chrome');
 


### PR DESCRIPTION
Allow user to block the headless browser from loading some requests.
Sample use case: block fonts/third party scripts/heavy media 