### PR TITLE
Add Chrome location detection on FreeBSD

### DIFF
--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -86,6 +86,10 @@ chrome.getChromeLocation = function() {
 	if (platform === 'darwin') {
 		return '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome';
 	}
+	
+	if (platform === 'freebsd') {
+		return '/usr/local/bin/chrome';
+	}
 
 	if (platform === 'linux') {
 		return '/usr/bin/google-chrome';


### PR DESCRIPTION
The commit contains a change that allows running prerender on FreeBSD without providing Chrome location. The chromium port and package install the binary in the specified path.