### PR TITLE
Add new Mixpanel API endpoint

### DIFF
--- a/lib/plugins/blockResources.js
+++ b/lib/plugins/blockResources.js
@@ -1,6 +1,7 @@
 const blockedResources = [
 	"google-analytics.com",
 	"api.mixpanel.com",
+	"api-js.mixpanel.com",
 	"fonts.googleapis.com",
 	"stats.g.doubleclick.net",
 	"mc.yandex.ru",


### PR DESCRIPTION
Prerender cache refresh requests started showing up in Mixpanel recently. Turns out requests for Mixpanel are now going to api-js.mixpanel.com. It's unclear whether this is a gradual rollout of a new endpoint, if the old one will go away, or what... so I kept `api.mixpanel.com` there as well.

I could probably get in touch with someone at mixpanel, but could handle that in a follow-up.