### PR TITLE
Return frailer exit code if there is exception

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -60,7 +60,7 @@ server.start = function() {
 
 	}).catch(() => {
 		if(process.exit) {
-			process.exit();
+			process.exit(1); // return exit code to show failer
 		}
 	});
 };


### PR DESCRIPTION
If you want to check the server exit non-normal in OS level, you must check the return code from the process. If the exit code is 0 then the process is finished normally. In other cases, there was an error. In node the following code is a normal exit from the process:

    process.exit();

In the server code, we exit normally on exception. So it is not possible to find out the process exit du to error. 

I add error code to the process to find out there is an exception.