### PR TITLE
Remove "_escaped_fragment_" stuff from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Below you will find documentation for our Prerender.io service (website SEO) and
 # Prerender.io
 ###### For serving your prerendered HTML to crawlers for SEO
 
-Prerender adheres to Google's `_escaped_fragment_` proposal, which we recommend you use. It's easy:
-- Just add &lt;meta name="fragment" content="!"> to the &lt;head> of all of your pages
-- If you use hash urls (#), change them to the hash-bang (#!)
+Prerender solves SEO by serving prerendered HTML to Google and other search engines.  It's easy:
+- Just install the appropriate middleware for your app (or check out the source code and build your own)
+- Make sure search engines have a way of discovering your pages (e.g. sitemap.xml and links from other parts of your site or from around the web)
 - That's it! Perfect SEO on javascript pages.
 
 


### PR DESCRIPTION
to match @thoop's [commit in prerender-node from earlier this year](https://github.com/prerender/prerender-node/commit/dcd5059ed95016ac5e2fd679305e856f698a63c7)

Also, sorta related: https://medium.com/finnovate-io/googlebot-no-longer-picking-up-content-in-prerender-io-pages-ae21d9710459

This change is just me paraphrasing @thoop's revised summary, but adapted to match the sort of step-by-step style that was going on before:
> This middleware intercepts requests to your Node.js website from crawlers, and then makes a call to the (external) Prerender Service to get the static HTML instead of the JavaScript for that page. That HTML is then returned to the crawler.

Making this change because @rachaelshaw and I were about to use prerender on a project, stumbled across this stuff about meta tags, and were like... "uhh wait a sec, is that relevant anymore?"

Hopefully this change saves others a few minutes down the road (since it seems this is no longer necessary)

I'll try my best to come back and check on this PR, but in case I miss your response and we're dead wrong about this, I'd really appreciate a heads up!  (feel free to DM me at [@mikermcneil](twitter.com/mikermcneil) or Rachael at [@rachaelshaw](twitter.com/rachaelshaw)

Thanks for a great product!  We'll be paying customers of the hosted prerender service within the next week :)