### PR TITLE
Implement HOST and PORT to replace the unimplemented PRERENDER_SERVICE_URL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,8 +10,9 @@ const bodyParser = require('body-parser');
 const compression = require('compression');
 
 exports = module.exports = (options = {}) => {
-	const parsedOptions = Object.assign({}, {		
-		port: options.port || process.env.PORT || 3000
+	const parsedOptions = Object.assign({}, {
+		host: options.host || process.env.HOST || "localhost",
+		port: options.port || process.env.PORT || 3000,
 	}, options)
 
 	server.init(options);


### PR DESCRIPTION
Hi all

One of my machines was exploited as a relay because the PRERENDER_SERVICE_URL was not honoured by the code.
So I implemented HOST and PORT separately to give more control to the users.

Cheers,
Stefan