### PR TITLE
include aws health check

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -213,6 +213,12 @@ server.onRequest = function(req, res) {
 	req.prerender.responseSent = false;
 	req.server = this;
 
+	if (!req.prerender.url || req.prerender.url.split('//').length < 2) {
+		req.prerender.documentHTML = "Incomplete or missing URL!";
+		res.send(200);
+	  return;
+	}
+
 	util.log('getting', req.prerender.url);
 	if (this.browserRequestsInFlight === undefined) {
 		return res.sendStatus(503);


### PR DESCRIPTION
Hello. I am making this small PR to suggest a possible fix to failed AWS health checks when using prerender. Following the beginning of this tutorial https://jakesen.github.io/aws/2016/10/31/setting-up-an-opsworks-stack-for-prerender.html , I have added a check for a blank url to return a 200 so that AWS can show a prerender based target group as healthy. If this is not the location where this fix should be applied, please let me know.