### PR TITLE
adding useinsider domains to blocked urls for preventing unnecessary logs

### DIFF
--- a/lib/plugins/blockResources.js
+++ b/lib/plugins/blockResources.js
@@ -22,6 +22,8 @@ const blockedResources = [
 	"hn.inspectlet.com",
 	"tpc.googlesyndication.com",
 	"partner.googleadservices.com",
+	"hit.api.useinsider.com",
+	"log.api.useinsider.com",
 	".ttf",
 	".eot",
 	".otf",


### PR DESCRIPTION
These 2 domains below collects logs and events from real users. We need to be sure none of the crawlers or bots are inserting logs over these 2 apis.

https://useinsider.com/