### PR TITLE
Update child_process spawn to use shell

### DIFF
--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -37,7 +37,7 @@ chrome.spawn = function (options) {
 			'--disable-gpu',
 			'--remote-debugging-port=' + this.options.browserDebuggingPort,
 			'--hide-scrollbars',
-		]);
+		], {shell: true});
 
 		resolve();
 	});


### PR DESCRIPTION
Using `node:18-alpine` on kubernetes v1.24.0 with container runtime `containerd`, this stopped working. We have been able to get the code working by moving away from `musl libc` to `glibc` in a `node:18-slim` build.

As a service provider, one of our clients noticed that their prerender server was unable to communicate with chrome, installed using the Dockerfile below:

```dockerfile
FROM node:18-alpine

RUN apk update && \
    apk add --no-cache ca-certificates && \
    apk add chromium --no-cache && \
    npm install prerender@${PRERENDER_VERSION}  && \
    npm install prerender-memory-cache@${PRERENDER_MEMORY_VERSION} && \
    rm -rf /var/cache/apk/*


WORKDIR /app
COPY package.json package-lock.json index.js .
CMD node index.js
```

in all tests, we were using `node index.js` with the following js file:
```javascript

const prerender = require("prerender");
const cache = require("prerender-memory-cache");

const server = prerender({
  chromeLocation: process.env.CHROME_LOCATION || "/usr/lib/chromium/chrome",
  followRedirects: true,
  pageLoadTimeout: 60 * 1000,
  port: 3003,
  chromeFlags: [
    "--no-sandbox",
    "--headless",
    "--disable-gpu",
    "--remote-debugging-port=9222",
    "--disable-dev-shm-usage",
    "--hide-scrollbars",
  ],
});

server.use(cache);
server.start();
```

The experiment we ran, had prerender server run successfully in the following cases:
- kubernetes 1.22, container runtime dockerd, base image alpine (node:18-alpine)
- kubernetes 1.23, container runtime containerd, base image debian-slim (node:18-slim)
- kubernetes 1.24, container runtime containerd, base image debian-slim (node:18-slim)

The configurations which did not work:
- kubernetes 1.22, container runtime containerd, base image alpine (node:18-alpine)
- kubernetes 1.23, container runtime containerd, base image alpine (node:18-alpine)

We suspect that there is an issue with how node's child_process is spawning processes through `musl libc` (on alpine), and how that interacts with `containerd`. This was blocking production usage of `prerender` on node alpine.

For testing, here is a successfully working `node:18-slim` dockerfile:
```dockerfile
FROM node:18-slim

RUN apt-get update && apt-get install -y wget vim supervisor

RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
RUN apt-get install ./google-chrome-stable_current_amd64.deb -y
ENV CHROME_LOCATION=/usr/bin/google-chrome-stable

RUN groupadd -r chrome && useradd -r -g chrome -G audio,video chrome \
	&& mkdir -p /home/chrome && chown -R chrome:chrome /home/chrome

WORKDIR /home/chrome

COPY prerender.conf /etc/supervisor/conf.d/prerender.conf
COPY prerender prerender
COPY index.js package.json package-lock.json .

RUN npm ci
```

Whilst this does appear to be a `containerd` and `musl libc` problem, unless there are strong reasons not to allow spawning a process into a shell, please consider merging this. If this is not possible, please offer feedback on an approach which would be preferred by prerender folks!

Thank you :) 