### PR TITLE
Allow specifying chrome child process spawn args

### DIFF
--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -37,7 +37,7 @@ chrome.spawn = function (options) {
 			'--disable-gpu',
 			'--remote-debugging-port=' + this.options.browserDebuggingPort,
 			'--hide-scrollbars',
-		], {shell: true});
+		], this.options.chromeChildArgs || {});
 
 		resolve();
 	});


### PR DESCRIPTION
Not a full revert of #748 but allow consumers
to optionally specify args for the child process.
e.g. {shell:true} or {stdin:'inherit'}