### PR TITLE
fix checking for parseShadowDom option

### DIFF
--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -660,8 +660,7 @@ chrome.parseHtmlFromPage = function (tab) {
 			reject();
 		}, 5000);
 
-
-		const getHtmlFunctionText = tab.prerender.parseShadowDom
+		const getHtmlFunctionText = tab.prerender.parseShadowDom || this.options.parseShadowDom
 			? getHtmlWithShadowDomFunction.toString()
 			: getHtmlFunction.toString();
 


### PR DESCRIPTION
I've been testing using this against our new website which uses shadowdom for some of our content, however I found that the `parseShadowDom` option isn't actually being set on the `tab.prerender` object. By adding the check below we get the shadowdom content in the prerendered response.