### PR TITLE
add a healthcheck endpoint

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -217,6 +217,10 @@ server.onRequest = function(req, res) {
 	req.prerender.responseSent = false;
 	req.server = this;
 
+	if (req.url.indexOf('/health') === 0) {
+		return res.sendStatus(200);
+	}
+
 	util.log('getting', req.prerender.url);
 	if (this.browserRequestsInFlight === undefined) {
 		return res.sendStatus(503);


### PR DESCRIPTION
Adds a simple `/health` endpoint that returns a 200 and doesn't trigger extraneous log messages