### PR TITLE
Fix Chrome paths with spaces

### DIFF
--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -32,6 +32,11 @@ chrome.spawn = function (options) {
 			return reject();
 		}
 
+		// Escape whitespaces for shell command
+		if (location.includes(' ')) {
+			location = `"${location}"`;
+		}
+
 		this.chromeChild = spawn(location, this.options.chromeFlags || [
 			'--headless',
 			'--disable-gpu',
@@ -100,7 +105,7 @@ chrome.getChromeLocation = function () {
 	let platform = os.platform();
 
 	if (platform === 'darwin') {
-		return '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome';
+		return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 	}
 
 	if (platform === 'linux') {


### PR DESCRIPTION
The issue:

On MacOs the Chrome would not start, shell command ran but exited:
<img width="884" alt="image" src="https://github.com/prerender/prerender/assets/22796372/4bb929f9-2d6a-40a1-92d8-a87809c029e6">


The reason:

The backslashes in - `/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome` are not interpreted as literal characters by JS, but rather ignored and the resulting JS string was: `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`.

Fix:

To resolve this, we need to escape whitespaces as we would escape them in a shell command, by wrapping it in double quotes:
`"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"`

Related: https://github.com/nodejs/node/issues/7367#issuecomment-229728704