### PR TITLE
Fix unhandled exception on blockResources

### DIFF
--- a/lib/plugins/blockResources.js
+++ b/lib/plugins/blockResources.js
@@ -45,7 +45,6 @@ module.exports = {
 		});
 
 		req.prerender.tab.Network.requestIntercepted(({interceptionId, request}) => {
-
 			let shouldBlock = false;
 			blockedResources.forEach((substring) => {
 				if (request.url.indexOf(substring) >= 0) {
@@ -59,8 +58,9 @@ module.exports = {
 				interceptOptions.errorReason = 'Aborted';
 			}
 
-			req.prerender.tab.Network.continueInterceptedRequest(interceptOptions);
-
+			req.prerender.tab.Network.continueInterceptedRequest(interceptOptions).catch((error) => {
+				console.log('[blockResources] Error continuing intercepted request', error);
+			});
 		});
 	}
 };


### PR DESCRIPTION
Hello! After running a custom `server.js` with many plugins enabled, I've got an exception and the server just died, as you can see in the logs below:

```
[...]
2024-02-24T13:37:10.707Z Started Chrome: HeadlessChrome/122.0.6261.57
2024-02-24T13:37:11.853Z getting https://brasil.io/
2024-02-24T13:37:11.932Z + 1 https://brasil.io/
2024-02-24T13:37:11.933Z Initial request to https://brasil.io/
2024-02-24T13:37:13.284Z + 2 https://brasil.io/home/
2024-02-24T13:37:13.285Z Initial request redirected from https://brasil.io/home/ with status code 302
2024-02-24T13:37:13.291Z - 0 https://brasil.io/home/
/app/node_modules/chrome-remote-interface/lib/chrome.js:94
                                : new ProtocolError(request, response)
                                  ^

ProtocolError: Invalid InterceptionId.
    at /app/node_modules/chrome-remote-interface/lib/chrome.js:94:35
    at Chrome._handleMessage (/app/node_modules/chrome-remote-interface/lib/chrome.js:257:17)
    at WebSocket.<anonymous> (/app/node_modules/chrome-remote-interface/lib/chrome.js:235:22)
    at WebSocket.emit (node:events:519:28)
    at Receiver.receiverOnMessage (/app/node_modules/ws/lib/websocket.js:1068:20)
    at Receiver.emit (node:events:519:28)
    at Receiver.dataMessage (/app/node_modules/ws/lib/receiver.js:517:14)
    at /app/node_modules/ws/lib/receiver.js:468:23
    at /app/node_modules/ws/lib/permessage-deflate.js:308:9
    at /app/node_modules/ws/lib/permessage-deflate.js:391:7 {
  request: {
    method: 'Network.continueInterceptedRequest',
    params: { interceptionId: 'interception-job-1.1' },
    sessionId: undefined
  },
  response: { code: -32602, message: 'Invalid InterceptionId.' }
}

Node.js v21.6.2
```

Upon investigating, I identified that the exception was caused by the `Network.continueInterceptedRequest` call in `plugins/blockResources.js`. To prevent the server from crashing, I added a `catch` to just log the exception. Logs after the change:

```
[...]
2024-02-24T13:38:52.232Z Started Chrome: HeadlessChrome/122.0.6261.57
2024-02-24T13:38:58.349Z getting https://brasil.io/
2024-02-24T13:38:58.444Z + 1 https://brasil.io/
2024-02-24T13:38:58.445Z Initial request to https://brasil.io/
2024-02-24T13:38:58.893Z + 2 https://brasil.io/home/
2024-02-24T13:38:58.894Z Initial request redirected from https://brasil.io/home/ with status code 302
2024-02-24T13:38:58.900Z - 0 https://brasil.io/home/
[blockResources] Error continuing intercepted request ProtocolError: Invalid InterceptionId.
    at /app/node_modules/chrome-remote-interface/lib/chrome.js:94:35
    at Chrome._handleMessage (/app/node_modules/chrome-remote-interface/lib/chrome.js:257:17)
    at WebSocket.<anonymous> (/app/node_modules/chrome-remote-interface/lib/chrome.js:235:22)
    at WebSocket.emit (node:events:519:28)
    at Receiver.receiverOnMessage (/app/node_modules/ws/lib/websocket.js:1068:20)
    at Receiver.emit (node:events:519:28)
    at Receiver.dataMessage (/app/node_modules/ws/lib/receiver.js:517:14)
    at /app/node_modules/ws/lib/receiver.js:468:23
    at /app/node_modules/ws/lib/permessage-deflate.js:308:9
    at /app/node_modules/ws/lib/permessage-deflate.js:391:7 {
  request: {
    method: 'Network.continueInterceptedRequest',
    params: { interceptionId: 'interception-job-2.1' },
    sessionId: undefined
  },
  response: { code: -32602, message: 'Invalid InterceptionId.' }
}
```

...and the server did not die. :)

While this prevents server crashes, I'm unsure if further changes are needed to address the root cause of the exception.