### PR TITLE
Fix Chrome restart, enhance connection options and logging

### DIFF
--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -120,13 +120,13 @@ chrome.openTab = function (options) {
 		let browserContext = null;
 		let browser = null;
 
-		const connectToBrowser = async (target, port) => {
+		const connectToBrowser = async (host, port, target) => {
 			let remainingRetries = 5;
 			for(;;) {
 				try {
-					return await CDP({ target, port });
+					return await CDP({ host, port, target });
 				} catch (err) {
-					util.log(`Cannot connect to browser target=${target}, port=${port}, remainingRetries=${remainingRetries}`, err);
+					util.log(`Cannot connect to browser host=${host}, port=${port}, target=${target}, remainingRetries=${remainingRetries}`, err);
 					if (remainingRetries <= 0) {
 						throw err;
 					} else {
@@ -137,7 +137,7 @@ chrome.openTab = function (options) {
 			}
 		};
 
-		connectToBrowser(this.webSocketDebuggerURL, this.options.browserDebuggingPort)
+		connectToBrowser(this.options.browserDebuggingHost, this.options.browserDebuggingPort, this.webSocketDebuggerURL)
 			.then((chromeBrowser) => {
 				browser = chromeBrowser;
 
@@ -151,8 +151,7 @@ chrome.openTab = function (options) {
 					browserContextId
 				});
 			}).then(({ targetId }) => {
-
-				return connectToBrowser(targetId, this.options.browserDebuggingPort);
+				return connectToBrowser(this.options.browserDebuggingHost, this.options.browserDebuggingPort, targetId);
 			}).then((tab) => {
 
 				//we're going to put our state on the chrome tab for now

--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -1,5 +1,5 @@
 const CDP = require('chrome-remote-interface');
-const { spawn } = require('child_process');
+const { spawn } = require('node:child_process');
 const util = require('../util.js');
 const fs = require('fs');
 const os = require('os');
@@ -37,7 +37,8 @@ chrome.spawn = function (options) {
 			'--disable-gpu',
 			'--remote-debugging-port=' + this.options.browserDebuggingPort,
 			'--hide-scrollbars',
-		], {shell: true});
+		], {shell: true, detached: true});
+		// `detached` will group all the process so we can kill them easily
 
 		resolve();
 	});
@@ -53,7 +54,9 @@ chrome.onClose = function (callback) {
 
 chrome.kill = function () {
 	if (this.chromeChild) {
-		this.chromeChild.kill('SIGINT');
+		let signal = 'SIGINT';
+		util.log(`Sending ${signal} to browser PID group ${this.chromeChild.pid}`);
+		process.kill(-this.chromeChild.pid, signal);  // negative PID means the whole group
 	}
 };
 

--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -69,10 +69,10 @@ chrome.connect = function () {
 		}, 20 * 1000);
 
 		let connect = () => {
-			CDP.Version({ port: this.options.browserDebuggingPort }).then((info) => {
-
+			CDP.Version({ host: this.options.browserDebuggingHost, port: this.options.browserDebuggingPort }).then((info) => {
 				this.originalUserAgent = info['User-Agent'];
-				this.webSocketDebuggerURL = info.webSocketDebuggerUrl || 'ws://localhost:' + this.options.browserDebuggingPort + '/devtools/browser';
+				this.webSocketDebuggerURL = info.webSocketDebuggerUrl || `ws://${this.options.browserDebuggingHost}:${this.options.browserDebuggingPort}/devtools/browser`;
+				util.log(`Got webSocketDebuggerURL: ${this.webSocketDebuggerURL}`);
 				this.version = info.Browser;
 
 				clearTimeout(timeout);

--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -80,7 +80,7 @@ chrome.connect = function () {
 				resolve();
 
 			}).catch((err) => {
-				util.log('retrying connection to Chrome...');
+				util.log('Error while running CDP.Version (will retry)', err);
 				return setTimeout(connect, 1000);
 			});
 		};
@@ -124,9 +124,9 @@ chrome.openTab = function (options) {
 			let remainingRetries = 5;
 			for(;;) {
 				try {
-					return await CDP({ target, port});
+					return await CDP({ target, port });
 				} catch (err) {
-					util.log(`Cannot connect to browser port=${port} remainingRetries=${remainingRetries}`, err);
+					util.log(`Cannot connect to browser target=${target}, port=${port}, remainingRetries=${remainingRetries}`, err);
 					if (remainingRetries <= 0) {
 						throw err;
 					} else {
@@ -163,15 +163,15 @@ chrome.openTab = function (options) {
 				tab.prerender.errors = [];
 				tab.prerender.requests = {};
 				tab.prerender.numRequestsInFlight = 0;
-
 				return this.setUpEvents(tab);
 			}).then((tab) => {
-
 				resolve(tab);
-			}).catch((err) => { reject(err) });
+			}).catch((err) => {
+				util.log('Error on connectToBrowser (openTab) pipeline', err);
+				reject(err);
+			});
 	});
 };
-
 
 
 chrome.closeTab = function (tab) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -19,6 +19,7 @@ const ENABLE_SERVICE_WORKER = process.env.ENABLE_SERVICE_WORKER || false;
 //try to restart the browser only if there are zero requests in flight
 const BROWSER_TRY_RESTART_PERIOD = process.env.BROWSER_TRY_RESTART_PERIOD || 600000;
 
+const BROWSER_DEBUGGING_HOST = process.env.BROWSER_DEBUGGING_HOST || '127.0.0.1';
 const BROWSER_DEBUGGING_PORT = process.env.BROWSER_DEBUGGING_PORT || 9222;
 
 const TIMEOUT_STATUS_CODE = process.env.TIMEOUT_STATUS_CODE;
@@ -43,6 +44,7 @@ server.init = function(options) {
 	this.options.pdfOptions = this.options.pdfOptions || {
 		printBackground: true
 	};
+	this.options.browserDebuggingHost = this.options.browserDebuggingHost || BROWSER_DEBUGGING_HOST;
 	this.options.browserDebuggingPort = this.options.browserDebuggingPort || BROWSER_DEBUGGING_PORT;
 	this.options.timeoutStatusCode = this.options.timeoutStatusCode || TIMEOUT_STATUS_CODE;
 	this.options.parseShadowDom = this.options.parseShadowDom || PARSE_SHADOW_DOM;

--- a/lib/server.js
+++ b/lib/server.js
@@ -162,6 +162,7 @@ server.listenForBrowserClose = function() {
 	this.isBrowserClosing = false;
 
 	this.browser.onClose(() => {
+		util.log('Starting browser shutdown pipeline');
 		this.isBrowserConnected = false;
 		if(this.isBrowserClosing) {
 			util.log(`Stopped ${this.browser.name}`);


### PR DESCRIPTION
Overview of changes:

- I had a bad time running prerender and it was very difficult to check what was really happening, since some exceptions did not show the error message or variables, so I enhanced the logging for `chrome.connect` and `chrome.openTab` 
- Added the Chrome host as an option (could be used to force IPv4/IPv6 or to run Chrome remotely)
- Fixed Chrome restart procedure - now the main browser process is detached, so we can SIGINT the whole process group (prerender was not connecting).

Probably related to/fixes #761 #775 #758 #755 #753