### PR TITLE
fix: syntax error when using extraChromeFlags option

### DIFF
--- a/lib/browsers/chrome.js
+++ b/lib/browsers/chrome.js
@@ -32,7 +32,7 @@ chrome.spawn = function (options) {
 			return reject();
 		}
 
-		const chromeFlags = this.options.chromeFlags || [
+		let chromeFlags = this.options.chromeFlags || [
 			'--headless',
 			'--disable-gpu',
 			'--remote-debugging-port=' + this.options.browserDebuggingPort,


### PR DESCRIPTION
This PR fixes issue #781 